### PR TITLE
fix(conda install): add -y parameter to run command in silent mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -
   && bash ~/miniconda.sh -b -p ~/miniconda && rm ~/miniconda.sh
 
 # Install pip, numpy, scipy, xeus-cling, jupyter, and pyvista. Afterwards, install ipyvtk-simple.
-RUN conda install -c conda-forge pip numpy scipy xeus-cling jupyterlab pyvista nodejs \
+RUN conda install -y -c conda-forge pip numpy scipy xeus-cling jupyterlab pyvista nodejs \
   && pip install --no-cache-dir ipyvtk-simple itkwidgets && conda clean --all -f -y
 
 # Add necessary extensions for interactive output to Jupyter Lab.


### PR DESCRIPTION
Without this flag it's impossible to build docker image because of the prompt asking for the confirmation of the installation.